### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,12 +125,12 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+         <%= image_tag item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -138,11 +138,6 @@
           <%# //商品が売れていればsold outを表示しましょう %>
         </div>
         <% end %>
-      </li>
-      
-      <% @items.each do |item| %>
-        <li class='list'>
-          <%= image_tag item.image, class: "item-img" %>
           <div class='item-info'>
             <h3 class='item-name'>
               <%= item.name %>
@@ -155,8 +150,8 @@
               </div>
             </div>
           </div>
-        </li>
-      <% end %>
+      </li>
+    <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,35 +131,39 @@
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
-
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
         </div>
         <% end %>
       </li>
+      
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= image_tag item.image, class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
             商品を出品してね！

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -161,7 +161,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% if @items = nil %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -161,6 +161,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items = nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,6 +179,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Item, type: :model do
       it 'カテゴリーの選択が１だと登録できないこと' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category Select")
+        expect(@item.errors.full_messages).to include('Category Select')
       end
       it '商品の状態が未選択だと登録できないこと' do
         @item.status_id = ''
@@ -40,7 +40,7 @@ RSpec.describe Item, type: :model do
       it '商品の状態の選択が１だと登録できないこと' do
         @item.status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status Select")
+        expect(@item.errors.full_messages).to include('Status Select')
       end
       it '配送料の負担が未選択だと登録できないこと' do
         @item.delivery_fee_id = ''
@@ -50,7 +50,7 @@ RSpec.describe Item, type: :model do
       it '配送料の負担の選択が１だと登録できないこと' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee Select")
+        expect(@item.errors.full_messages).to include('Delivery fee Select')
       end
       it '発送元の地域が未選択だと登録できないこと' do
         @item.prefecture_id = ''
@@ -60,7 +60,7 @@ RSpec.describe Item, type: :model do
       it '発送元の地域の選択が１だと登録できないこと' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture Select")
+        expect(@item.errors.full_messages).to include('Prefecture Select')
       end
       it '発送までの日数が未選択だと登録できないこと' do
         @item.shipping_day_id = ''
@@ -70,7 +70,7 @@ RSpec.describe Item, type: :model do
       it '発送までの日数の選択が１だと登録できないこと' do
         @item.shipping_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping day Select")
+        expect(@item.errors.full_messages).to include('Shipping day Select')
       end
       it '販売価格が空だと登録できないこと' do
         @item.price = ''
@@ -83,7 +83,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price must be greater than 300')
       end
       it '販売価格が9999999以上だと登録できないこと' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than 9999999')
       end
@@ -100,12 +100,12 @@ RSpec.describe Item, type: :model do
       it '販売価格は（半角英数字混合）だと登録できないこと' do
         @item.price = '123abc'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '販売価格は（半角英語）だと登録できないこと' do
         @item.price = 'abcdefg'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '出品画像が空だと登録できないこと' do
         @item.image = nil


### PR DESCRIPTION
# what
**商品一覧表示機能**
- indexのルーティング設定
- コントローラーへindexアクション設定
- ビューファイルへitemsテーブルの情報取得する記述
- 出品商品が無い時のダミー画像設定

# why
**商品一覧表示機能のため**

[商品一覧表示・更新後](https://i.gyazo.com/3915c4da4820e6b4db1c19e635cab09f.png)
[商品表示順変更](https://i.gyazo.com/83aeef484282296211ffe6b1d9d76987.png)